### PR TITLE
Fix Docker assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -270,6 +270,18 @@ lazy val server = project
     coverageMinimumStmtTotal := 85,
     coverageFailOnMinimum := true,
     scalafmtOnCompile := true,
+    assembly / assemblyMergeStrategy := {
+      case PathList("META-INF", "io.netty.versions.properties", _ @_*) => MergeStrategy.discard
+      case PathList("codegen-resources", "customization.config", _ @_*) => MergeStrategy.discard
+      case PathList("codegen-resources", "examples-1.json", _ @_*) => MergeStrategy.discard
+      case PathList("codegen-resources", "paginators-1.json", _ @_*) => MergeStrategy.discard
+      case PathList("codegen-resources", "service-2.json", _ @_*) => MergeStrategy.discard
+      case PathList("codegen-resources", "waiters-2.json", _ @_*) => MergeStrategy.discard
+      case PathList("module-info.class") => MergeStrategy.discard
+      case x =>
+        val oldStrategy = (assembly / assemblyMergeStrategy).value
+        oldStrategy(x)
+    },
     docker / dockerfile := {
       val artifact: File = assembly.value
       val artifactTargetPath = s"/app/${artifact.name}"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,7 +14,7 @@ credentials += Credentials(
 // See https://app.clickup.com/t/a8ned9
 ThisBuild / useCoursier := false
 
-addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
+addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.9.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 


### PR DESCRIPTION
# Description

The AWS SDK version update introduced new jars that contain identical paths with different contents, causing the sbt assembly to fail. These files are not needed at runtime, so this PR discards them from the assembly.

Also got an error from sbt-docker about not being able to parse image id. Updating the sbt-docker version fixed that.
