### PR TITLE
Fix ManifestS3 PUT

### DIFF
--- a/server/src/main/scala/com/pennsieve/jobscheduling/clients/ManifestS3Client.scala
+++ b/server/src/main/scala/com/pennsieve/jobscheduling/clients/ManifestS3Client.scala
@@ -93,16 +93,10 @@ class ManifestS3Client(awsS3Client: S3Client, etlBucket: String) {
 
 object ManifestS3Client {
 
-  val clientOverrideConfiguration: ClientOverrideConfiguration = ClientOverrideConfiguration
-    .builder()
-    .putAdvancedOption(SdkAdvancedClientOption.SIGNER, Aws4Signer.create())
-    .build()
-
   def apply(s3Config: S3Config): ManifestS3Client = {
     val amazonS3Client =
       S3Client
         .builder()
-        .overrideConfiguration(clientOverrideConfiguration)
         .credentialsProvider(DefaultCredentialsProvider.create())
         .region(s3Config.awsRegion)
         .build()


### PR DESCRIPTION
# Description

This PR removes the S3 client config code that attempted to specify version 4 signing of S3 requests. This is already the default signer for AWS Java SDK v2, so is redundant. It also seemed to have been incorrect since the S3 requests ended up missing a required auth header. 

PR #1 updated the AWS Java SDK version and introduced this bug