### PR TITLE
Update task definition resource reference to include version wildcard

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -26,7 +26,7 @@ data "aws_iam_policy_document" "iam_policy_document" {
       "ecs:StopTask",
     ]
 
-    resources = ["arn:aws:ecs:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:task-definition/${data.terraform_remote_state.etl_nextflow.outputs.ecs_task_definition_family}"]
+    resources = [local.etl_nextflow_task_definition_arn_wildcard_version]
   }
 
   statement {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -191,5 +191,7 @@ locals {
 
   service = element(split("-", var.service_name), 0)
   tier    = element(split("-", var.service_name), 1)
+
+  etl_nextflow_task_definition_arn_wildcard_version = "arn:aws:ecs:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:task-definition/${data.terraform_remote_state.etl_nextflow.outputs.ecs_task_definition_family}:*"
 }
 


### PR DESCRIPTION
# Description

On October 15 AWS will require task definition ARNs used as resources in IAM policies for certain actions to either include a specific version suffix or a wildcard suffix to give permission on all versions. This PR updates an IAM policy to use the wildcard suffix.

See ticket for details, including the original email from AWS.

[Update IAM Policies for change to ECS Authorization](https://app.clickup.com/t/8688znju1)
